### PR TITLE
Add MLB gamepk lookup route and page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,99 @@
-from flask import Flask, send_from_directory
+import datetime as dt
+import json
+import urllib.request
+import urllib.error
+from urllib.parse import urlencode
+from flask import Flask, send_from_directory, render_template, request, jsonify
 
-app = Flask(__name__, static_folder='static')
+from mlb import FullSchedule
+
+
+app = Flask(__name__, static_folder='static', template_folder='templates')
+
+
+SPORT_IDS = {
+    'MLB': 1,
+    'AAA': 11,
+    'AA': 12,
+    'A+': 13,
+    'A': 14,
+    'ROOKIE BALL': 16,
+    'WINTER LEAGUE': 17,
+    'IND': 23,
+}
+
+
+def fetch_schedule(date: str, league: str):
+    sport_id = SPORT_IDS.get(league, SPORT_IDS['MLB'])
+    params = urlencode({'sportId': sport_id, 'date': date})
+    url = f'https://statsapi.mlb.com/api/v1/schedule?{params}'
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        data = json.load(resp)
+    games = []
+    for day in data.get('dates', []):
+        for g in day.get('games', []):
+            games.append(FullSchedule(g, league))
+    games.sort(key=lambda g: g.get_datetime())
+    return games
+
+
+@app.route('/gamepk_lookup', methods=['GET', 'POST'])
+def gamepk_lookup():
+    error = None
+    games = []
+    date_val = ''
+    league_val = ''
+
+    if request.method == 'POST':
+        date_val = request.form.get('date', '').strip()
+        league_val = request.form.get('league', '').strip()
+        if not date_val:
+            error = 'Date is required.'
+        else:
+            try:
+                dt.datetime.strptime(date_val, '%Y-%m-%d')
+                games = fetch_schedule(date_val, league_val or 'MLB')
+                if not games:
+                    error = 'No games scheduled for that date.'
+            except ValueError:
+                error = 'Invalid date format. Use YYYY-MM-DD.'
+            except urllib.error.URLError:
+                error = 'Error retrieving schedule.'
+
+    return render_template(
+        'gamepk_lookup.html',
+        games=games,
+        error=error,
+        sport_ids=SPORT_IDS,
+        selected_date=date_val,
+        selected_league=league_val,
+    )
+
+
+@app.route('/api/gamepk_lookup')
+def gamepk_lookup_api():
+    date_val = request.args.get('date', '').strip()
+    league_val = request.args.get('league', '').strip()
+    if not date_val:
+        return jsonify({'error': 'Date is required'}), 400
+    try:
+        dt.datetime.strptime(date_val, '%Y-%m-%d')
+        games = fetch_schedule(date_val, league_val or 'MLB')
+    except ValueError:
+        return jsonify({'error': 'Invalid date format. Use YYYY-MM-DD.'}), 400
+    except urllib.error.URLError:
+        return jsonify({'error': 'Error retrieving schedule'}), 502
+
+    result = [
+        {
+            'game_pk': g.game_pk,
+            'home_team': g.home_team.name,
+            'away_team': g.away_team.name,
+            'status': g.detailed_state,
+        }
+        for g in games
+    ]
+    return jsonify({'games': result})
 
 @app.route('/')
 def index():

--- a/mlb.py
+++ b/mlb.py
@@ -1,0 +1,89 @@
+import datetime as dt
+
+
+class Team:
+    def __init__(self, team_data: dict):
+        self.name = team_data.get('team', {}).get('name')
+        self.id = team_data.get('team', {}).get('id')
+        self.link = team_data.get('team', {}).get('link')
+        self.wins = team_data.get('leagueRecord', {}).get('wins')
+        self.losses = team_data.get('leagueRecord', {}).get('losses')
+        self.pct = team_data.get('leagueRecord', {}).get('pct')
+        self.score = team_data.get('score')
+        self.is_winner = team_data.get('isWinner', False)
+        self.split_squad = team_data.get('splitSquad', False)
+        self.series_number = team_data.get('seriesNumber')
+
+    def __repr__(self):
+        return (
+            f"Team(name={self.name}, id={self.id}, wins={self.wins}, "
+            f"losses={self.losses}, pct={self.pct}, score={self.score}, "
+            f"is_winner={self.is_winner})"
+        )
+
+
+class LiteSchedule:
+    def __init__(self, game_data: dict, league):
+        self.league = league
+        self.game_data = game_data
+        self.game_pk = game_data.get('gamePk')
+        self.game_guid = game_data.get('gameGuid')
+        self.link = game_data.get('link')
+        self.game_type = game_data.get('gameType')
+        self.season = game_data.get('season')
+        self.date = game_data.get('gameDate')
+        self.official_date = game_data.get('officialDate')
+
+        status = game_data.get('status', {})
+        self.abstract_game_state = status.get('abstractGameState')
+        self.coded_game_state = status.get('codedGameState')
+        self.detailed_state = status.get('detailedState')
+        self.status_code = status.get('statusCode')
+        self.start_time_tbd = status.get('startTimeTBD', False)
+        self.abstract_game_code = status.get('abstractGameCode')
+        self.reason = status.get('reason')
+
+        self.reschedule_date = game_data.get('rescheduleDate')
+        self.reschedule_game_date = game_data.get('rescheduleGameDate')
+        self.rescheduled_from = game_data.get('rescheduledFrom')
+        self.rescheduled_from_date = game_data.get('rescheduledFromDate')
+        self.is_rescheduled = True if self.reschedule_date else False
+
+    def get_datetime(self) -> dt.datetime:
+        raw_date = self.reschedule_date or self.date
+        utc_time = dt.datetime.strptime(raw_date, '%Y-%m-%dT%H:%M:%SZ')
+        utc_time = utc_time.replace(tzinfo=dt.timezone.utc)
+        return utc_time
+
+
+class FullSchedule(LiteSchedule):
+    def __init__(self, game_data: dict, league):
+        super().__init__(game_data, league)
+        teams = game_data.get('teams', {})
+        self.away_team = Team(teams.get('away', {}))
+        self.home_team = Team(teams.get('home', {}))
+
+        self.venue = game_data.get('venue', {}).get('name')
+        self.venue_id = game_data.get('venue', {}).get('id')
+        self.venue_link = game_data.get('venue', {}).get('link')
+        self.content_link = game_data.get('content', {}).get('link')
+
+        self.scheduled_innings = game_data.get('scheduledInnings', 9)
+        self.games_in_series = game_data.get('gamesInSeries')
+        self.series_game_number = game_data.get('seriesGameNumber')
+        self.series_description = game_data.get('seriesDescription')
+        self.is_tie = game_data.get('isTie', False)
+        self.double_header = game_data.get('doubleHeader', 'N')
+        self.gameday_type = game_data.get('gamedayType')
+        self.day_night = game_data.get('dayNight')
+        self.description = game_data.get('description')
+
+    def __repr__(self):
+        return (
+            f"Game(game_pk={self.game_pk}, date={self.date}, official_date={self.official_date}, "
+            f"status={{'abstract': {self.abstract_game_state}, 'coded': {self.coded_game_state}, "
+            f"'detailed': {self.detailed_state}, 'reason': {self.reason}}}, "
+            f"home_team={self.home_team}, away_team={self.away_team}, "
+            f"venue={self.venue}, series={{'games_in_series': {self.games_in_series}, "
+            f"'series_game_number': {self.series_game_number}, 'description': {self.series_description}}})"
+        )

--- a/static/index.html
+++ b/static/index.html
@@ -9,6 +9,7 @@
   <ul>
     <li><a href="http://metabase.loosesocket.com">Metabase</a></li>
     <li><a href="http://loosesocket.com">Landing Page (You Are Here)</a></li>
+    <li><a href="/gamepk_lookup">Gamepk Lookup</a></li>
     <!-- Add more links as needed -->
   </ul>
   <h2>pitchclip Downloads</h2>

--- a/templates/gamepk_lookup.html
+++ b/templates/gamepk_lookup.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Gamepk Lookup</title>
+</head>
+<body>
+    <h1>Gamepk Lookup</h1>
+    <form method="post">
+        <label for="date">Date:</label>
+        <input type="date" id="date" name="date" required value="{{ selected_date }}">
+        <label for="league">League:</label>
+        <select id="league" name="league">
+            {% for name in sport_ids.keys() %}
+                <option value="{{ name }}" {% if (selected_league and selected_league == name) or (not selected_league and name == 'MLB') %}selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit">Search</button>
+    </form>
+
+    {% if error %}
+        <p style="color:red;">{{ error }}</p>
+    {% endif %}
+
+    {% if games %}
+        <table border="1" cellspacing="0" cellpadding="5">
+            <thead>
+                <tr><th>Matchup</th><th>Game PK</th></tr>
+            </thead>
+            <tbody>
+                {% for g in games %}
+                    <tr>
+                        <td>{{ g.home_team.name }} vs {{ g.away_team.name }}</td>
+                        <td>{{ g.game_pk }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add gamepk lookup page for viewing game_pks by date and league
- fetch schedule data from MLB Stats API and render results
- expose JSON endpoint for gamepk lookup

## Testing
- `python -m py_compile app.py mlb.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a23612dfe88330ab44fadd88c3a2cd